### PR TITLE
Tweak the description for the slice type

### DIFF
--- a/Pyjion/absvalue.cpp
+++ b/Pyjion/absvalue.cpp
@@ -965,5 +965,5 @@ AbstractValue* SliceValue::unary(AbstractSource* selfSources, int op) {
     return AbstractValue::unary(selfSources, op);
 }
 const char* SliceValue::describe() {
-    return "Slice";
+    return "slice";
 }


### PR DESCRIPTION
Make it lowercase to match Python's naming.

Closes #38