### PR TITLE
Prevent infinite recursion when comparing string subtypes

### DIFF
--- a/Pyjion/intrins.cpp
+++ b/Pyjion/intrins.cpp
@@ -158,7 +158,7 @@ int PyJit_RichEquals_Long(PyObject *left, PyObject *right, void**state) {
 
 int PyJit_RichEquals_Generic(PyObject *left, PyObject *right, void**state) {
     if (left->ob_type == right->ob_type) {
-        if (PyUnicode_Check(left)) {
+        if (PyUnicode_CheckExact(left)) {
             *state = &PyJit_RichEquals_Str;
             return PyJit_RichEquals_Str(left, right, state);
         }

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -268,6 +268,22 @@ void PyJitTest() {
             TestInput("True")
         ),
         TestCase(
+            "def f():\n    x = 'a'\n    y = 'b'\n    if x == y:\n        return True\n    return False",
+            TestInput("False")
+        ),
+        TestCase(
+            "def f():\n    x = 'a'\n    y = 'a'\n    if x == y:\n        return True\n    return False",
+            TestInput("True")
+        ),
+        TestCase(
+            "def f():\n    class Foo(str): pass\n    x = Foo(1)\n    y = Foo(2)\n    if x == y:        return True\n    return False",
+            TestInput("False")
+        ),
+        TestCase(
+            "def f():\n    class Foo(str): pass\n    x = Foo(1)\n    y = Foo(1)\n    if x == y:        return True\n    return False",
+            TestInput("True")
+        ),
+        TestCase(
         "def f():\n    x = 2.0\n    y = 3.0\n    if x != y:\n        return True\n    return False",
         TestInput("True")
         ),


### PR DESCRIPTION
Discovered by running Python's chameleon_v2 benchmark.