### PR TITLE
Fix unary float operations

### DIFF
--- a/Pyjion/absint.h
+++ b/Pyjion/absint.h
@@ -306,6 +306,14 @@ private:
 	void unpack_sequence(size_t size, int opcode);
 	Local get_optimized_local(int index, AbstractValueKind kind);
 	void pop_except();
+
+	void unary_positive(int opcodeIndex);
+	void unary_negative(int opcodeIndex);
+	void unary_not(int& opcodeIndex);
+
+	void jump_if_or_pop(bool isTrue, int opcodeIndex, int offset);
+	void pop_jump_if(bool isTrue, int opcodeIndex, int offset);
+	void test_bool_and_branch(Local value, bool isTrue, Label target);
 };
 
 

--- a/Pyjion/ilgen.h
+++ b/Pyjion/ilgen.h
@@ -262,6 +262,10 @@ public:
         }
     }
 
+	void neg() {
+		m_il.push_back(CEE_NEG);
+	}
+
     void dup() {
         m_il.push_back(CEE_DUP);
     }

--- a/Pyjion/ipycomp.h
+++ b/Pyjion/ipycomp.h
@@ -109,6 +109,8 @@ class IPythonCompiler {
 	virtual void emit_float(double value) = 0;
 	// Emits an unboxed bool onto the stack
 	virtual void emit_bool(bool value) = 0;
+	// Emits a pointer value onto the stack
+	virtual void emit_ptr(void* value) = 0;
 	// Emits the address of a Python object on the stack, bumping its ref count
 	virtual void emit_py_object(PyObject* value) = 0;
 	// Emits a null pointer onto the stack
@@ -231,10 +233,8 @@ class IPythonCompiler {
 	// Creates a slice object from values on the stack
 	virtual void emit_build_slice() = 0;
 
-	// Jumps if the current value is true/false, otherwise pops the current value
-	virtual void emit_jump_if_or_pop(bool isTrue, Label target) = 0;
-	// Jumps if the current value is true/false
-	virtual void emit_pop_jump_if(bool isTrue, Label target) = 0;
+	// Pushes an unboxed bool onto the stack indicating the truthiness of the top value on the stack
+	virtual void emit_is_true() = 0;
 
 	// Imports the specified name
 	virtual void emit_import_name(PyObject* name) = 0;
@@ -297,9 +297,15 @@ class IPythonCompiler {
 	// Performs a unary not, pushing the Python object result onto the stack, or NULL if an error occurred
 	virtual void emit_unary_not() = 0;
 	// Perform a unary not, pushing an unboxed int onto the stack indicating true (1), false (0), or error
-	virtual void emit_unary_not_int() = 0;
+	virtual void emit_unary_not_push_int() = 0;
+
+	// Does a unary not on an unboxed floating value, pushing an unboxed bool onto the stack
+	virtual void emit_unary_not_float_push_bool() = 0;
 	// Performs a unary invert on the top value on the stack, pushing the result onto the stack or NULL if an error occurred
 	virtual void emit_unary_invert() = 0;
+
+	// Peforms a unary negative on a unboxed floating value on the stack, pushing the unboxed result back to the stack
+	virtual void emit_unary_negative_float() = 0;
 
 	// Performans a binary operation for values on the stack which are unboxed floating points
 	virtual void emit_binary_float(int opcode) = 0;
@@ -309,21 +315,21 @@ class IPythonCompiler {
 	// Does an in/contains check and pushes a Python object onto the stack as the result, or NULL if there was an error
 	virtual void emit_in() = 0;
 	// Does an in/contains check and pushes an unboxed int onto the stack indicating true (1)/false (0)/error (-1)
-	virtual void emit_in_int() = 0;
+	virtual void emit_in_push_int() = 0;
 	// Does an not in check and pushes a Python object onto the stack as the result, or NULL if there was an error
 	virtual void emit_not_in() = 0;
 	// Does an not in check and pushes an unboxed int onto the stack indicating true (1)/false (0)/error (-1)
-	virtual void emit_not_in_int() = 0;
+	virtual void emit_not_in_push_int() = 0;
 
 	// Does an is check and pushes a boxed Python bool on the stack as the result
 	virtual void emit_is(bool isNot) = 0;
 	// Does an is check and pushes an unboxed bool onto the stack
-	virtual void emit_is_int(bool isNot) = 0;
+	virtual void emit_is_push_int(bool isNot) = 0;
 	
 	// Performs a comparison for values on the stack which are objects, keeping a boxed Python object as the result.
 	virtual void emit_compare_object(int compareType) = 0;
 	// Performs a comparison of two Python objects on the stack keeping an unboxed bool on the stack as the result
-	virtual bool emit_compare_object_int(int compareType) = 0;
+	virtual bool emit_compare_object_push_int(int compareType) = 0;
 	// Performs a comparison of two unboxed floating point values on the stack
 	virtual void emit_compare_float(int compareType) = 0;
 

--- a/Pyjion/pycomp.h
+++ b/Pyjion/pycomp.h
@@ -217,9 +217,8 @@ public:
 
     virtual void emit_dup_top_two();
 
-    virtual void emit_jump_if_or_pop(bool isTrue, Label target);
-    virtual void emit_pop_jump_if(bool isTrue, Label target);
     virtual void emit_load_name(PyObject* name);
+	virtual void emit_is_true();
 
 	virtual void emit_push_frame();
 	virtual void emit_pop_frame();
@@ -261,8 +260,12 @@ public:
 
     virtual void emit_unary_positive();
     virtual void emit_unary_negative();
-    virtual void emit_unary_not_int();
-    virtual void emit_unary_not();
+	virtual void emit_unary_negative_float();
+
+	virtual void emit_unary_not();
+
+	virtual void emit_unary_not_push_int();
+	virtual void emit_unary_not_float_push_bool();
     virtual void emit_unary_invert();
 
     virtual void emit_import_name(PyObject* name);
@@ -323,18 +326,18 @@ public:
     virtual void emit_binary_float(int opcode);
     virtual void emit_binary_object(int opcode);
     
-    virtual void emit_in_int();
+    virtual void emit_in_push_int();
     virtual void emit_in();
-    virtual void emit_not_in_int();
+    virtual void emit_not_in_push_int();
     virtual void emit_not_in();
 
-    virtual void emit_is_int(bool isNot);
+    virtual void emit_is_push_int(bool isNot);
 
     virtual void emit_is(bool isNot);
 
     virtual void emit_compare_object(int compareType);
     virtual void emit_compare_float(int compareType);
-    virtual bool emit_compare_object_int(int compareType);
+    virtual bool emit_compare_object_push_int(int compareType);
 
 	virtual void emit_store_fast(int local);
 
@@ -375,7 +378,6 @@ public:
 	
 private:
     void load_frame();
-	void test_bool_and_branch(Local value, bool isTrue, Label target);
 
     void load_local(int oparg);
     void incref();

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -218,7 +218,7 @@ void PyJitTest() {
         //    TestInput("True")
         //),
 
-        TestCase(
+		TestCase(
             "def f():\n    try:\n        min(1,2)\n    finally:\n        try:\n            min(1,2)\n        except EnvironmentError:\n            pass\n    return 1",
             TestInput("1")
             ),
@@ -227,7 +227,31 @@ void PyJitTest() {
             TestInput("1")
             ),
         // Simple optimized code test cases...
-        TestCase(
+		TestCase(
+			"def f():\n    x = 1.0\n    y = +x\n    return y",
+			TestInput("1.0")
+			),
+		TestCase(
+			"def f():\n    x = 1.0\n    if not x:\n        return 1\n    return 2",
+			TestInput("2")
+			),
+		TestCase(
+			"def f():\n    x = 0.0\n    if not x:\n        return 1\n    return 2",
+			TestInput("1")
+			),
+		TestCase(
+			"def f():\n    x = 1.0\n    y = -x\n    return y",
+			TestInput("-1.0")
+			),
+		TestCase(
+			"def f():\n    x = 1.0\n    y = not x\n    return y",
+			TestInput("False")
+			),
+		TestCase(
+			"def f():\n    x = 0.0\n    y = not x\n    return y",
+			TestInput("True")
+			),
+		TestCase(
             "def f():\n    x = 1.0\n    return x",
             TestInput("1.0")
         ),


### PR DESCRIPTION
Fix unary operations on unboxed floats
Moves jump_if_or_pop/pop_jump_if logic into abstract interpreter
Changes naming convention for values that push non-boxed values onto the stack so it doesn't get confusing with more unboxed values coming into play
