### PR TITLE
Fix test_decimal

### DIFF
--- a/Pyjion/absint.h
+++ b/Pyjion/absint.h
@@ -206,6 +206,7 @@ class __declspec(dllexport) AbstractInterpreter {
     //      raise logic.
     //  This was so we don't need to have decref/frees spread all over the code
     vector<vector<Label>> m_raiseAndFree, m_reraiseAndFree;
+    unordered_set<size_t> m_jumpsTo;
     Label m_retLabel;
     Local m_retValue;
     // Stores information for a stack allocated local used for sequence unpacking.  We need to allocate
@@ -339,6 +340,7 @@ private:
     Local get_optimized_local(int index, AbstractValueKind kind);
     void pop_except();
 
+    bool can_optimize_pop_jump(int opcodeIndex);
     void unary_positive(int opcodeIndex);
     void unary_negative(int opcodeIndex);
     void unary_not(int& opcodeIndex);

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -213,6 +213,10 @@ void PyJitTest() {
     PyList_SetItem(list, 0, PyLong_FromLong(42));
 
     TestCase cases[] = {
+        TestCase(
+            "def f(a, q, r):\n    if not (a == q and r == 0):\n        return 42\n    return 23",
+            TestInput("42", vector<PyObject*>({ PyLong_FromLong(2), PyLong_FromLong(4), PyLong_FromLong(7) }))
+        ),
         // Break from nested try/finally needs to use BranchLeave to clear the stack
         TestCase(
             "def f():\n    for i in range(5):\n        try:\n            raise Exception()\n        finally:\n            try:\n                break\n            finally:\n                pass\n    return 42",


### PR DESCRIPTION
The code "if not (a == q and r == 0):" gets turned into cascading
POP_IFs, and we need to disable the optimization which avoids putting
a bool on the stack.