### PR TITLE
More EH fixes

### DIFF
--- a/Pyjion/absint.h
+++ b/Pyjion/absint.h
@@ -95,7 +95,7 @@ struct ExceptionVars {
     // The previous traceback and exception values if we're handling a finally block.
     // We store these in locals and keep only the exception type on the stack so that
     // we don't enter the finally handler with multiple stack depths.
-    Local FinallyTb, FinallyValue;
+    Local FinallyExc, FinallyTb, FinallyValue;
 
     ExceptionVars() {
     }
@@ -105,6 +105,7 @@ struct ExceptionVars {
         PrevExcVal = comp->emit_define_local(false);
         PrevTraceback = comp->emit_define_local(false);
         if (isFinally) {
+            FinallyExc = comp->emit_define_local(false);
             FinallyTb = comp->emit_define_local(false);;
             FinallyValue = comp->emit_define_local(false);
         }

--- a/Pyjion/intrins.cpp
+++ b/Pyjion/intrins.cpp
@@ -675,10 +675,13 @@ const char * ObjInfo(PyObject *obj);
 
 void PyJit_PyErrRestore(PyObject*tb, PyObject*value, PyObject*exception) {
 #ifdef DEBUG_TRACE
-    printf("Restoring exception %s\r\n", ObjInfo(exception));
-    printf("Restoring value %s\r\n", ObjInfo(value));
-    printf("Restoring tb %s\r\n", ObjInfo(tb));
+    printf("Restoring exception %p %s\r\n", exception, ObjInfo(exception));
+    printf("Restoring value %p %s\r\n", value, ObjInfo(value));
+    printf("Restoring tb %p %s\r\n", tb, ObjInfo(tb));
 #endif
+    if (exception == Py_None) {
+        exception = nullptr;
+    }
     PyErr_Restore(exception, value, tb);
 }
 

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -214,6 +214,18 @@ void PyJitTest() {
 
     TestCase cases[] = {
         TestCase(
+            "def f():\n    try:\n         raise TypeError('hi')\n    except Exception as e:\n         pass\n    finally:\n         pass",
+            TestInput("None")
+        ),
+        TestCase(
+            "def f():\n    try:\n        try:\n             raise Exception('hi')\n        finally:\n             pass\n    finally:\n        pass",
+            TestInput("<NULL>")
+        ),
+        TestCase(
+            "def f():\n    try:\n        try:\n             try:\n                  raise TypeError('err')\n             except BaseException:\n                  raise\n        finally:\n             pass\n    finally:\n        return 42\n",
+            TestInput("42")
+        ),
+        TestCase(
             "def f():\n    def f(self) -> 42 : pass\n    return 42",
             TestInput("42")
         ),


### PR DESCRIPTION
    try/try/raise/finally/finally should re-throw existing exception
        We were restoring the wrong exception at the end of a finally, leading to
        the exception instance & traceback being cleared.  Now we use BackHandler to
        store in the correct handler when entering a finally block during an exception, and
        then restore the correct values when we hit the END_FINALLY
    try/try/finally/finally/return should clear existing exception
        When we returned from a finally we weren't properly clearing the
        current exception in flight.
    When restoring an error if there is no exception (the type is Py_None) we need to
        pass NULL to PyErr_Restore, otherwise PyErr_Occurred reports that an exception
        is still happening.