### PR TITLE
Interpret DELETE_DEREF

### DIFF
--- a/Pyjion/absint.cpp
+++ b/Pyjion/absint.cpp
@@ -706,10 +706,16 @@ bool AbstractInterpreter::interpret() {
                     lastState.push(&Set);
                     break;
                 case STORE_DEREF:
+                    // There is no tracking of cell variables.
                     lastState.pop();
                     break;
                 case LOAD_DEREF:
+                    // There is no tracking of cell variables.
                     lastState.push(&Any);
+                    break;
+                case DELETE_DEREF:
+                    // Since cell variables are not tracked, no need to worry
+                    // about their deletion.
                     break;
                 case GET_ITER:
                     // TODO: Known iterable types


### PR DESCRIPTION
Since cell variables are not tracking during abstract interpretion, all we
have to do is simply recognize the opcode and do nothing.

Fixes #105 