### PR TITLE
Fix #120

### DIFF
--- a/Pyjion/absint.cpp
+++ b/Pyjion/absint.cpp
@@ -40,6 +40,7 @@ AbstractInterpreter::AbstractInterpreter(PyCodeObject *code, IPythonCompiler* co
     if (comp != nullptr) {
         m_retLabel = comp->emit_define_label();
         m_retValue = comp->emit_define_local();
+        m_errorCheckLocal = comp->emit_define_local();
     }
 }
 
@@ -1323,12 +1324,13 @@ void AbstractInterpreter::int_error_check(char* reason) {
 void AbstractInterpreter::error_check(char *reason) {
     auto noErr = m_comp->emit_define_label();
     m_comp->emit_dup();
+    m_comp->emit_store_local(m_errorCheckLocal);
     m_comp->emit_null();
     m_comp->emit_branch(BranchNotEqual, noErr);
 
-    m_comp->emit_pop();
     branch_raise(reason);
     m_comp->emit_mark_label(noErr);
+    m_comp->emit_load_local(m_errorCheckLocal);
 }
 
 Label AbstractInterpreter::getOffsetLabel(int jumpTo) {
@@ -1341,6 +1343,19 @@ Label AbstractInterpreter::getOffsetLabel(int jumpTo) {
         jumpToLabel = jumpToLabelIter->second;
     }
     return jumpToLabel;
+}
+
+void AbstractInterpreter::ensure_raise_and_free_locals(size_t localCount) {
+    while (m_raiseAndFreeLocals.size() <= localCount) {
+        m_raiseAndFreeLocals.push_back(m_comp->emit_define_local());
+    }
+}
+
+void AbstractInterpreter::spill_stack_for_raise(size_t localCount) {
+    ensure_raise_and_free_locals(localCount);
+    for (size_t i = 0; i < localCount; i++) {
+        m_comp->emit_store_local(m_raiseAndFreeLocals[i]);
+    }
 }
 
 vector<Label>& AbstractInterpreter::get_raise_and_free_labels(size_t blockId) {
@@ -1412,6 +1427,7 @@ void AbstractInterpreter::branch_raise(char *reason) {
 
         ensure_labels(labels, count);
 
+        spill_stack_for_raise(count);
         m_comp->emit_branch(BranchAlways, labels[count - 1]);
     }
 }
@@ -2206,6 +2222,7 @@ JittedCode* AbstractInterpreter::compile_worker() {
                                     ensure_labels(raiseLabels, count);
                                     ensure_labels(reraiseLabels, count);
 
+                                    spill_stack_for_raise(count);
                                     m_comp->emit_branch(BranchFalse, raiseLabels[count - 1]);
                                     m_comp->emit_branch(BranchAlways, reraiseLabels[count - 1]);
                                     noStack = false;
@@ -2529,16 +2546,18 @@ JittedCode* AbstractInterpreter::compile_worker() {
 void AbstractInterpreter::emit_raise_and_free(size_t handlerIndex) {
     auto handler = m_allHandlers[handlerIndex];
     auto reraiseAndFreeLabels = get_reraise_and_free_labels(handler.RaiseAndFreeId);
-    for (auto curLabel = reraiseAndFreeLabels.rbegin(); curLabel != reraiseAndFreeLabels.rend(); curLabel++) {
-        m_comp->emit_mark_label(*curLabel);
+    for (auto cur = reraiseAndFreeLabels.size() - 1; cur != -1; cur--) {
+        m_comp->emit_mark_label(reraiseAndFreeLabels[cur]);
+        m_comp->emit_load_local(m_raiseAndFreeLocals[cur]);
         m_comp->emit_pop_top();
     }
     if (reraiseAndFreeLabels.size() != 0) {
         m_comp->emit_branch(BranchAlways, handler.ReRaise);
     }
     auto raiseAndFreeLabels = get_raise_and_free_labels(handler.RaiseAndFreeId);
-    for (auto curLabel = raiseAndFreeLabels.rbegin(); curLabel != raiseAndFreeLabels.rend(); curLabel++) {
-        m_comp->emit_mark_label(*curLabel);
+    for (auto cur = raiseAndFreeLabels.size() - 1; cur != -1; cur--) {
+        m_comp->emit_mark_label(raiseAndFreeLabels[cur]);
+        m_comp->emit_load_local(m_raiseAndFreeLocals[cur]);
         m_comp->emit_pop_top();
     }
 
@@ -3210,10 +3229,19 @@ void AbstractInterpreter::load_fast_worker(int local, bool checkUnbound) {
     if (checkUnbound) {
         Label success = m_comp->emit_define_label();
 
+        m_comp->emit_dup();
+        m_comp->emit_store_local(m_errorCheckLocal);
+        m_comp->emit_null();
+        m_comp->emit_branch(BranchNotEqual, success);
+
+        m_comp->emit_ptr(PyTuple_GetItem(m_code->co_varnames, local));
+
         m_comp->emit_unbound_local_check(local, success);
+        
         branch_raise();
 
         m_comp->emit_mark_label(success);
+        m_comp->emit_load_local(m_errorCheckLocal);
     }
 
     m_comp->emit_dup();

--- a/Pyjion/absint.cpp
+++ b/Pyjion/absint.cpp
@@ -3236,7 +3236,7 @@ void AbstractInterpreter::load_fast_worker(int local, bool checkUnbound) {
 
         m_comp->emit_ptr(PyTuple_GetItem(m_code->co_varnames, local));
 
-        m_comp->emit_unbound_local_check(local, success);
+        m_comp->emit_unbound_local_check();
         
         branch_raise();
 

--- a/Pyjion/absint.h
+++ b/Pyjion/absint.h
@@ -165,6 +165,7 @@ class __declspec(dllexport) AbstractInterpreter {
     PyCodeObject* m_code;
     unsigned char *m_byteCode;
     size_t m_size;
+    Local m_errorCheckLocal;
 
     // ** Data consumed during analysis:
     // Tracks whether an END_FINALLY is being consumed by a finally block (true) or exception block (false)
@@ -179,6 +180,7 @@ class __declspec(dllexport) AbstractInterpreter {
     // all values produced during abstract interpretation, need to be freed
     vector<AbstractValue*> m_values;
     vector<AbstractSource*> m_sources;
+    vector<Local> m_raiseAndFreeLocals;
     IPythonCompiler* m_comp;
     // m_blockStack is like Python's f_blockstack which lives on the frame object, except we only maintain
     // it at compile time.  Blocks are pushed onto the stack when we enter a loop, the start of a try block,
@@ -282,7 +284,9 @@ private:
 
     vector<Label>& get_raise_and_free_labels(size_t blockId);
     vector<Label>& get_reraise_and_free_labels(size_t blockId);
+    void ensure_raise_and_free_locals(size_t localCount);
     void emit_raise_and_free(size_t handlerIndex);
+    void spill_stack_for_raise(size_t localCount);
 
     void ensure_labels(vector<Label>& labels, size_t count);
 

--- a/Pyjion/ipycomp.h
+++ b/Pyjion/ipycomp.h
@@ -173,7 +173,7 @@ public:
     virtual void emit_load_fast(int local) = 0;
     virtual void emit_store_fast(int local) = 0;
     virtual void emit_delete_fast(int index, PyObject* name) = 0;
-    virtual void emit_unbound_local_check(int local, Label success) = 0;
+    virtual void emit_unbound_local_check() = 0;
 
     // Loads/stores/deletes by name for values not known to be in fast locals
     virtual void emit_load_name(PyObject* name) = 0;

--- a/Pyjion/pycomp.cpp
+++ b/Pyjion/pycomp.cpp
@@ -213,15 +213,9 @@ Local PythonCompiler::emit_allocate_stack_array(size_t bytes) {
  * Compiler interface implementation
  */
 
-void PythonCompiler::emit_unbound_local_check(int local, Label success) {
+void PythonCompiler::emit_unbound_local_check() {
     //// TODO: Remove this check for definitely assigned values (e.g. params w/ no dels, 
     //// locals that are provably assigned)
-    m_il.dup();
-    m_il.load_null();
-    m_il.branch(BranchNotEqual, success);
-
-    m_il.pop();
-    m_il.ld_i(PyTuple_GetItem(m_code->co_varnames, local));
     m_il.emit_call(METHOD_UNBOUND_LOCAL);
 }
 
@@ -1110,7 +1104,6 @@ JittedCode* PythonCompiler::emit_compile() {
         delete jitInfo;
         return nullptr;
     }
-
     return jitInfo;
 
 }

--- a/Pyjion/pycomp.h
+++ b/Pyjion/pycomp.h
@@ -363,7 +363,7 @@ public:
 
     virtual void emit_store_fast(int local);
 
-    virtual void emit_unbound_local_check(int local, Label success);
+    virtual void emit_unbound_local_check();
     virtual void emit_load_fast(int local);
 
     virtual Label emit_define_label();


### PR DESCRIPTION
The JIT is emitting lots of temporary spills when we do a branch
with a value on the stack.  This leads to a huge frame size.  Most
of these branches are happening on our branches for error checks.

This stores the value in a temp and reloads it instead of branching
with the value on the stack.  This greatly reduces the number of
these, but once we get something like:

a() + b()

Where we do an error check on the result of b() we still have the
result of a() on the stack, which causes us to still spill.  This
at least gets us passing on this test, but we'll need to see if
we can be more efficient in the future, or if we just need to store
all of the values around an error check.