### PR TITLE
Rename header guard definitions to follow conventions in the C++ standard

### DIFF
--- a/Pyjion/absint.h
+++ b/Pyjion/absint.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __ABSINT_H__
-#define __ABSINT_H__
+#ifndef ABSINT_H
+#define ABSINT_H
 
 #include <Python.h>
 #include <vector>

--- a/Pyjion/absvalue.h
+++ b/Pyjion/absvalue.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __ABSVALUE_H__
-#define __ABSVALUE_H__
+#ifndef ABSVALUE_H
+#define ABSVALUE_H
 
 #include <python.h>
 #include <opcode.h>

--- a/Pyjion/cee.h
+++ b/Pyjion/cee.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __CEE_H__
-#define __CEE_H__
+#ifndef CEE_H
+#define CEE_H
 
 #define FEATURE_NO_HOST
 #define USE_STL

--- a/Pyjion/codemodel.h
+++ b/Pyjion/codemodel.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __CODEMODEL_H__
-#define __CODEMODEL_H__
+#ifndef CODEMODEL_H
+#define CODEMODEL_H
 
 #define FEATURE_NO_HOST
 #define USE_STL

--- a/Pyjion/cowvector.h
+++ b/Pyjion/cowvector.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __COWVECTOR_H__
-#define __COWVECTOR_H__
+#ifndef COWVECTOR_H
+#define COWVECTOR_H
 
 #include <memory>
 #include <vector>

--- a/Pyjion/ilgen.h
+++ b/Pyjion/ilgen.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __ILGEN_H__
-#define __ILGEN_H__
+#ifndef ILGEN_H
+#define ILGEN_H
 
 #define FEATURE_NO_HOST
 #define USE_STL

--- a/Pyjion/intrins.h
+++ b/Pyjion/intrins.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __INTRINS_H__
-#define __INTRINS_H__
+#ifndef INTRINS_H
+#define INTRINS_H
 
 #include <Python.h>
 #include <frameobject.h>

--- a/Pyjion/ipycomp.h
+++ b/Pyjion/ipycomp.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __IPYCOMP_H__
-#define __IPYCOMP_H__
+#ifndef IPYCOMP_H
+#define IPYCOMP_H
 
 class Local {
 public:

--- a/Pyjion/jitinfo.h
+++ b/Pyjion/jitinfo.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __JITINFO_H__
-#define __JITINFO_H__
+#ifndef JITINFO_H
+#define JITINFO_H
 
 
 #define FEATURE_NO_HOST

--- a/Pyjion/jitinit.h
+++ b/Pyjion/jitinit.h
@@ -1,5 +1,5 @@
-#ifndef __JITINIT_H__
-#define __JITINIT_H__
+#ifndef JITINIT_H
+#define JITINIT_H
 
 
 #define FEATURE_NO_HOST

--- a/Pyjion/pycomp.h
+++ b/Pyjion/pycomp.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __PYCOMP_H__
-#define __PYCOMP_H__
+#ifndef PYCOMP_H
+#define PYCOMP_H
 
 #include <stdint.h>
 #include <windows.h>

--- a/Pyjion/pyjit.h
+++ b/Pyjion/pyjit.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __PYJIT_H__
-#define __PYJIT_H__
+#ifndef PYJIT_H
+#define PYJIT_H
 
 #define FEATURE_NO_HOST
 #define USE_STL

--- a/Pyjion/taggedptr.h
+++ b/Pyjion/taggedptr.h
@@ -23,8 +23,8 @@
 *
 */
 
-#ifndef __TAGGED_PTR_H__
-#define __TAGGED_PTR_H__
+#ifndef TAGGED_PTR_H
+#define TAGGED_PTR_H
 
 #include <Python.h>
 


### PR DESCRIPTION
Closes #139 