### PR TITLE
Improve ROT_TWO support

### DIFF
--- a/Pyjion/ipycomp.h
+++ b/Pyjion/ipycomp.h
@@ -82,7 +82,7 @@ class IPythonCompiler {
 public:
     /*****************************************************
      * Basic Python stack manipulations */
-    virtual void emit_rot_two() = 0;
+    virtual void emit_rot_two(LocalKind kind = LK_Pointer) = 0;
     virtual void emit_rot_three() = 0;
     // Pops the top value from the stack and decrements its refcount
     virtual void emit_pop_top() = 0;

--- a/Pyjion/pycomp.cpp
+++ b/Pyjion/pycomp.cpp
@@ -258,9 +258,9 @@ void PythonCompiler::emit_store_fast(int local) {
     decref();
 }
 
-void PythonCompiler::emit_rot_two() {
-    auto top = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
-    auto second = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
+void PythonCompiler::emit_rot_two(LocalKind kind) {
+    auto top = m_il.define_local(Parameter(to_clr_type(kind)));
+    auto second = m_il.define_local(Parameter(to_clr_type(kind)));
 
     m_il.st_loc(top);
     m_il.st_loc(second);

--- a/Pyjion/pycomp.h
+++ b/Pyjion/pycomp.h
@@ -235,7 +235,7 @@ class PythonCompiler : public IPythonCompiler {
 public:
     PythonCompiler(PyCodeObject *code);
 
-    virtual void emit_rot_two();
+    virtual void emit_rot_two(LocalKind kind = LK_Pointer);
 
     virtual void emit_rot_three();
 

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -1672,7 +1672,16 @@ void PyJitTest() {
                     TestInput("142", vector<PyObject*>({ PyLong_FromLong(42), PyLong_FromLong(100) })),
                     TestInput("'abcdef'", vector<PyObject*>({ PyUnicode_FromString("abc"), PyUnicode_FromString("def") }))
                 })
-        )
+        ),
+        TestCase(
+            "def f(a, b):\n    return (b, a)",
+            vector<TestInput>({
+                TestInput("(2, 1)", vector<PyObject*>({ PyLong_FromLong(1), PyLong_FromLong(2) })),
+                TestInput("(2.2, 1.1)", vector<PyObject*>({ PyFloat_FromDouble(1.1), PyFloat_FromDouble(2.2) })),
+                TestInput("('def', 'abc')", vector<PyObject*>({ PyUnicode_FromString("abc"), PyUnicode_FromString("def") })),
+                TestInput("(2.2, 1)", vector<PyObject*>({ PyLong_FromLong(1), PyFloat_FromDouble(2.2) })),
+            })
+        ),
     };
 
 
@@ -1926,7 +1935,59 @@ void AbsIntTest() {
             new BoxVerifier(28, false),  // INPLACE_ADD
             new BoxVerifier(29, false),  // STORE_FAST x
         }
-        )
+        ),
+        // Swap two ints...
+        AITestCase(
+        "def f():\n    x = 1\n    y = 2\n    (x, y) = (y, x)",
+        {
+            new BoxVerifier(0, false),  // LOAD_CONST  1 (1)
+            new BoxVerifier(3, false),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, false),  // LOAD_CONST  2 (2)
+            new BoxVerifier(9, false),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, false), // LOAD_FAST   1 (y)
+            new BoxVerifier(15, false), // LOAD_FAST   0 (x)
+            new BoxVerifier(18, false), // ROT_TWO
+            new BoxVerifier(19, false), // STORE_FAST  0 (x)
+            new BoxVerifier(22, false), // STORE_FAST  1 (y)
+        }),
+        // Swap two floats...
+        AITestCase(
+        "def f():\n    x = 1.1\n    y = 2.2\n    (x, y) = (y, x)",
+        {
+            new BoxVerifier(0, false),  // LOAD_CONST  1 (1.1)
+            new BoxVerifier(3, false),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, false),  // LOAD_CONST  2 (2.2)
+            new BoxVerifier(9, false),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, false), // LOAD_FAST   1 (y)
+            new BoxVerifier(15, false), // LOAD_FAST   0 (x)
+            new BoxVerifier(18, false), // ROT_TWO
+            new BoxVerifier(19, false), // STORE_FAST  0 (x)
+            new BoxVerifier(22, false), // STORE_FAST  1 (y)
+        }),
+        // Swap two objects of unknown type...
+        AITestCase(
+        "def f(x, y):\n    (x, y) = (y, x)",
+        {
+            new BoxVerifier(0, true),  // LOAD_FAST   1 (y)
+            new BoxVerifier(3, true),  // LOAD_FAST   0 (x)
+            new BoxVerifier(6, true),  // ROT_TWO
+            new BoxVerifier(7, true),  // STORE_FAST  0 (x)
+            new BoxVerifier(10, true), // STORE_FAST  1 (y)
+        }),
+        // Mix floats and ints...
+        AITestCase(
+        "def f():\n    x = 1\n    y = 2.2\n    (x, y) = (y, x)",
+        {
+            new BoxVerifier(0, true),  // LOAD_CONST  1 (1)
+            new BoxVerifier(3, true),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, true),  // LOAD_CONST  2 (2.2)
+            new BoxVerifier(9, true),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, true), // LOAD_FAST   1 (y)
+            new BoxVerifier(15, true), // LOAD_FAST   0 (x)
+            new BoxVerifier(18, true), // ROT_TWO
+            new BoxVerifier(19, true), // STORE_FAST  0 (x)
+            new BoxVerifier(22, true), // STORE_FAST  1 (y)
+        }),
     };
 
     for (auto& testCase : cases) {


### PR DESCRIPTION
This partially fixes #88 by improving how code for ROT_TWO
is generated.  In particular, optimized locals are used for
integers and floats.  A similar fix will be made for ROT_THREE
in a following patch.