### PR TITLE
Always jit tests

### DIFF
--- a/Pyjion/absint.cpp
+++ b/Pyjion/absint.cpp
@@ -689,6 +689,13 @@ bool AbstractInterpreter::interpret() {
                         sources
                         );
 
+                    // TODO: The code generator currently assumes it is *always* dealing
+                    // with an object (i.e. not an unboxed value).  Support should be
+                    // added to the code generator for dealing with unboxed values.  The
+                    // code below that forces an escape should then be removed.
+                    if (opcode == UNARY_INVERT)
+                        one.escapes();
+
                     lastState.push(AbstractValueWithSources(unaryRes, sources));
                     break;
                 }

--- a/Pyjion/pyjit.cpp
+++ b/Pyjion/pyjit.cpp
@@ -65,6 +65,7 @@ __declspec(dllexport) PyjionJittedCode *jittedcode_new_direct() {
     new_ob->j_failed = false;
     new_ob->j_evalfunc = nullptr;
     new_ob->j_evalstate = nullptr;
+    new_ob->j_specialization_threshold = 500;
 
     return new_ob;
 }
@@ -244,7 +245,8 @@ PyObject* __stdcall Jit_EvalTrace(void* state, PyFrameObject *frame) {
     }
 
     // No specialized function yet, let's see if we should create one...
-    if (curNode->hitCount > 500) {
+    auto jittedCode = (PyjionJittedCode *)trace->code->co_extra;
+    if (curNode->hitCount > jittedCode->j_specialization_threshold) {
         // Compile and run the now compiled code...
         PythonCompiler jitter(trace->code);
         AbstractInterpreter interp(trace->code, &jitter);

--- a/Pyjion/pyjit.h
+++ b/Pyjion/pyjit.h
@@ -62,6 +62,7 @@ typedef struct {
     bool j_failed;
     Py_EvalFunc j_evalfunc;
     void* j_evalstate;          /* opaque value, allows the JIT to track any relevant state */
+    PY_UINT64_T j_specialization_threshold;
 } PyjionJittedCode;
 
 __declspec(dllexport) PyjionJittedCode *jittedcode_new_direct();

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -1688,6 +1688,9 @@ void PyJitTest() {
         if (addr == nullptr) {
             _ASSERT(FALSE);
         }
+        // For the purpose of exercising the JIT machinery while testing, the
+        // code should be JITed everytime.
+        addr->j_specialization_threshold = 0;
         codeObj->co_extra = (PyObject *)addr;
         if (!jit_compile(codeObj) || addr->j_evalfunc == nullptr) {
             _ASSERT(FALSE);


### PR DESCRIPTION
When investigating issue #88 I noticed that the JIT tests were *not* actually running the JIT everytime because the specialization threshold was never being surpassed.  Forcing the code to be always JITed exposed a bug in the generation of unary inverts.  This patch series fixes the unary invert bug and adds an option to specify the specialization threshold option that is overriden by the test code.