### PR TITLE
Improve ROT_THREE support

### DIFF
--- a/Pyjion/absint.cpp
+++ b/Pyjion/absint.cpp
@@ -252,12 +252,21 @@ bool AbstractInterpreter::interpret() {
                 }
                 case ROT_THREE:
                 {
-                    // ROT_THREE currently assumes we have native ints on the stack,
-                    // so we force escape here...  We should fix that up in the future
-                    // and use pop_no_escape
-                    auto top = lastState.pop();
-                    auto second = lastState.pop();
-                    auto third = lastState.pop();
+                    auto top = lastState.pop_no_escape();
+                    auto second = lastState.pop_no_escape();
+                    auto third = lastState.pop_no_escape();
+
+                    auto sources = AbstractSource::combine(
+                        top.Sources,
+                        AbstractSource::combine(second.Sources, third.Sources));
+                    m_opcodeSources[opcodeIndex] = sources;
+
+                    if (top.Value->kind() != second.Value->kind()
+                        || top.Value->kind() != third.Value->kind()) {
+                        top.escapes();
+                        second.escapes();
+                        third.escapes();
+                    }
 
                     lastState.push(top);
                     lastState.push(third);
@@ -2004,17 +2013,24 @@ JittedCode* AbstractInterpreter::compile_worker() {
             }
             case ROT_THREE: 
             {
-                bool top = m_stack.back();
-                m_stack.pop_back();
-                bool second = m_stack.back();
-                m_stack.pop_back();
-                bool third = m_stack.back();
-                m_stack.pop_back();
+                std::swap(m_stack[m_stack.size() - 1], m_stack[m_stack.size() - 2]);
+                std::swap(m_stack[m_stack.size() - 2], m_stack[m_stack.size() - 3]);
 
-                m_stack.push_back(top);
-                m_stack.push_back(third);
-                m_stack.push_back(second);
+                if (!should_box(opcodeIndex)) {
+                    auto stackInfo = get_stack_info(opcodeIndex);
+                    auto top_kind = stackInfo[stackInfo.size() - 1].Value->kind();
+                    auto second_kind = stackInfo[stackInfo.size() - 2].Value->kind();
+                    auto third_kind = stackInfo[stackInfo.size() - 3].Value->kind();
 
+                    if (top_kind == AVK_Float && second_kind == AVK_Float && third_kind == AVK_Float) {
+                        m_comp->emit_rot_three(LK_Float);
+                        break;
+                    }
+                    else if (top_kind == AVK_Integer && second_kind == AVK_Integer && third_kind == AVK_Integer) {
+                        m_comp->emit_rot_three(LK_Int);
+                        break;
+                    }
+                }
                 m_comp->emit_rot_three();
                 break;
             }

--- a/Pyjion/ipycomp.h
+++ b/Pyjion/ipycomp.h
@@ -83,7 +83,7 @@ public:
     /*****************************************************
      * Basic Python stack manipulations */
     virtual void emit_rot_two(LocalKind kind = LK_Pointer) = 0;
-    virtual void emit_rot_three() = 0;
+    virtual void emit_rot_three(LocalKind kind = LK_Pointer) = 0;
     // Pops the top value from the stack and decrements its refcount
     virtual void emit_pop_top() = 0;
     // Dups the top value on the stack (and bumps its ref count)

--- a/Pyjion/pycomp.cpp
+++ b/Pyjion/pycomp.cpp
@@ -272,10 +272,10 @@ void PythonCompiler::emit_rot_two(LocalKind kind) {
     m_il.free_local(second);
 }
 
-void PythonCompiler::emit_rot_three() {
-    auto top = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
-    auto second = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
-    auto third = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
+void PythonCompiler::emit_rot_three(LocalKind kind) {
+    auto top = m_il.define_local(Parameter(to_clr_type(kind)));
+    auto second = m_il.define_local(Parameter(to_clr_type(kind)));
+    auto third = m_il.define_local(Parameter(to_clr_type(kind)));
 
     m_il.st_loc(top);
     m_il.st_loc(second);

--- a/Pyjion/pycomp.h
+++ b/Pyjion/pycomp.h
@@ -237,7 +237,7 @@ public:
 
     virtual void emit_rot_two(LocalKind kind = LK_Pointer);
 
-    virtual void emit_rot_three();
+    virtual void emit_rot_three(LocalKind kind = LK_Pointer);
 
     virtual void emit_pop_top();
 

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -1682,6 +1682,15 @@ void PyJitTest() {
                 TestInput("(2.2, 1)", vector<PyObject*>({ PyLong_FromLong(1), PyFloat_FromDouble(2.2) })),
             })
         ),
+        TestCase(
+            "def f(a, b, c):\n    (a, b, c) = (b, c, a)\n    return (a, b, c)",
+            vector<TestInput>({
+                TestInput("(2, 3, 1)", vector<PyObject*>({ PyLong_FromLong(1), PyLong_FromLong(2), PyLong_FromLong(3) })),
+                TestInput("(2.2, 3.3, 1.1)", vector<PyObject*>({ PyFloat_FromDouble(1.1), PyFloat_FromDouble(2.2), PyFloat_FromDouble(3.3) })),
+                TestInput("('def', 'ghi', 'abc')", vector<PyObject*>({ PyUnicode_FromString("abc"), PyUnicode_FromString("def"), PyUnicode_FromString("ghi") })),
+                TestInput("(2.2, 3, 1)", vector<PyObject*>({ PyLong_FromLong(1), PyFloat_FromDouble(2.2), PyLong_FromLong(3) })),
+            })
+        ),
     };
 
 
@@ -1990,6 +1999,76 @@ void AbsIntTest() {
             new BoxVerifier(18, true), // ROT_TWO
             new BoxVerifier(19, true), // STORE_FAST  0 (x)
             new BoxVerifier(22, true), // STORE_FAST  1 (y)
+        }),
+        // Swap three ints...
+        AITestCase(
+        "def f():\n    x = 1\n    y = 2\n    z = 3\n    (x, y, z) = (y, z, x)",
+        {
+            new BoxVerifier(0, false),  // LOAD_CONST  1 (1)
+            new BoxVerifier(3, false),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, false),  // LOAD_CONST  2 (2)
+            new BoxVerifier(9, false),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, false), // LOAD_CONST  3 (3)
+            new BoxVerifier(15, false), // STORE_FAST  2 (z)
+            new BoxVerifier(18, false), // LOAD_FAST   1 (y)
+            new BoxVerifier(21, false), // LOAD_FAST   2 (z)
+            new BoxVerifier(24, false), // LOAD_FAST   0 (x)
+            new BoxVerifier(27, false), // ROT_THREE
+            new BoxVerifier(28, false), // ROT_TWO
+            new BoxVerifier(29, false), // STORE_FAST  0 (x)
+            new BoxVerifier(32, false), // STORE_FAST  1 (y)
+            new BoxVerifier(35, false), // STORE_FAST  2 (z)
+        }),
+        // Swap three floats...
+        AITestCase(
+        "def f():\n    x = 1.1\n    y = 2.2\n    z = 3.3\n    (x, y, z) = (y, z, x)",
+        {
+            new BoxVerifier(0, false),  // LOAD_CONST  1 (1.1)
+            new BoxVerifier(3, false),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, false),  // LOAD_CONST  2 (2.2)
+            new BoxVerifier(9, false),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, false), // LOAD_CONST  3 (3.3)
+            new BoxVerifier(15, false), // STORE_FAST  2 (z)
+            new BoxVerifier(18, false), // LOAD_FAST   1 (y)
+            new BoxVerifier(21, false), // LOAD_FAST   2 (z)
+            new BoxVerifier(24, false), // LOAD_FAST   0 (x)
+            new BoxVerifier(27, false), // ROT_THREE
+            new BoxVerifier(28, false), // ROT_TWO
+            new BoxVerifier(29, false), // STORE_FAST  0 (x)
+            new BoxVerifier(32, false), // STORE_FAST  1 (y)
+            new BoxVerifier(35, false), // STORE_FAST  2 (z)
+        }),
+        // Swap three objects of unknown type...
+        AITestCase(
+        "def f(x, y, z):\n    (x, y, z) = (y, z, x)",
+        {
+            new BoxVerifier(0, true),  // LOAD_FAST   1 (y)
+            new BoxVerifier(3, true),  // LOAD_FAST   2 (z)
+            new BoxVerifier(6, true),  // LOAD_FAST   0 (x)
+            new BoxVerifier(9, true),  // ROT_THREE
+            new BoxVerifier(10, true), // ROT_TWO
+            new BoxVerifier(11, true), // STORE_FAST  0 (x)
+            new BoxVerifier(14, true), // STORE_FAST  1 (y)
+            new BoxVerifier(17, true), // STORE_FAST  2 (z)
+        }),
+        // Mix floats and ints...
+        AITestCase(
+        "def f():\n    x = 1.1\n    y = 2\n    z = 3.3\n    (x, y, z) = (y, z, x)",
+        {
+            new BoxVerifier(0, true),  // LOAD_CONST  1 (1.1)
+            new BoxVerifier(3, true),  // STORE_FAST  0 (x)
+            new BoxVerifier(6, true),  // LOAD_CONST  2 (2)
+            new BoxVerifier(9, true),  // STORE_FAST  1 (y)
+            new BoxVerifier(12, true), // LOAD_CONST  3 (3.3)
+            new BoxVerifier(15, true), // STORE_FAST  2 (z)
+            new BoxVerifier(18, true), // LOAD_FAST   1 (y)
+            new BoxVerifier(21, true), // LOAD_FAST   2 (z)
+            new BoxVerifier(24, true), // LOAD_FAST   0 (x)
+            new BoxVerifier(27, true), // ROT_THREE
+            new BoxVerifier(28, true), // ROT_TWO
+            new BoxVerifier(29, true), // STORE_FAST  0 (x)
+            new BoxVerifier(32, true), // STORE_FAST  1 (y)
+            new BoxVerifier(35, true), // STORE_FAST  2 (z)
         }),
     };
 


### PR DESCRIPTION
This patch changes the implementation of ROT_THREE to only
escape its operands when the types are not all ints or
all floats.  Furthermore, the ROT_THREE code generator has
been enhanced to use the appropriate type for defining
locals.

This is the companion patch to 539866f0ec5e3595bfd5e8c9117084f2517dbc58
and is the last patch to properly resolve issue #88.