### PR TITLE
Fix crash on Linux caused by out of range read only data

### DIFF
--- a/BuildDeps.cmd
+++ b/BuildDeps.cmd
@@ -41,7 +41,7 @@ if /i "%__BuildArch%" == "x64" set arch=amd64
 set SUFFIX=
 if /i "%__BuildType%" == "Debug" set SUFFIX=_d
 
-copy %arch%\python35%SUFFIX%.lib ..\..\Libs\%__BuildType%\%__BuildArch%\
+copy %arch%\python36%SUFFIX%.lib ..\..\Libs\%__BuildType%\%__BuildArch%\
 popd
 
 :Done

--- a/Pyjion/cee.h
+++ b/Pyjion/cee.h
@@ -321,7 +321,11 @@ public:
     BOOL ClrHeapDestroy(
         HANDLE hHeap   // handle to heap
         ) {
+#ifdef PLATFORM_UNIX
+		return FALSE;
+#else
         return ::HeapDestroy(hHeap);
+#endif
     }
 
     LPVOID ClrHeapAlloc(

--- a/Pyjion/jitinfo.h
+++ b/Pyjion/jitinfo.h
@@ -106,11 +106,11 @@ public:
 
 #ifdef PLATFORM_UNIX
 		// The JIT will produce accesses to the roDataBlock which are relative
-		// to the generate code and uses 32-bit offsets to access it.  Therefore
+		// to the generated code and uses 32-bit offsets to access it.  Therefore
 		// if we have a range that's greater than 32-bits the access will be invalid
-		// fail.  On Windows malloc() is returning addresses close to the executable
+		// and fail.  On Windows, malloc() is returning addresses close to the executable
 		// heap and everything is okay.  On Linux we're currently just allocating the
-		// executable + ro blocks together so we know they're close.  This has the downsize
+		// executable + ro blocks together so we know they're close.  This has the downside
 		// that we have some data which is marked as executable which isn't the best.
 #define ALIGN(size, align) \
     (((size)+((align)-1)) & ~((align)-1))


### PR DESCRIPTION
Fix up BuildDeps.cmd so that it copies the correct version